### PR TITLE
Add compartmentalized inventory UI and logic with item catalog and migration

### DIFF
--- a/_includes/inventory_popup.html
+++ b/_includes/inventory_popup.html
@@ -1,7 +1,22 @@
 <div id="inventory-popup" class="popup">
     <div class="popup-content">
         <h2>Inventory</h2>
-        <ul id="inventory-list"></ul>
+        <form id="inventory-add-form">
+            <label for="inventory-item-select">Item</label>
+            <select id="inventory-item-select"></select>
+
+            <label for="inventory-compartment-select">Compartment</label>
+            <select id="inventory-compartment-select">
+                <option value="back">Back</option>
+                <option value="belt">Belt</option>
+                <option value="hands">Hands</option>
+            </select>
+
+            <button type="submit">Add Item</button>
+        </form>
+
+        <p id="inventory-message" aria-live="polite"></p>
+        <div id="inventory-list"></div>
         <button id="close-inventory">Close</button>
     </div>
 </div>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -166,6 +166,38 @@ h1 {
     }
 }
 
+#inventory-add-form {
+    display: grid;
+    gap: 8px;
+
+    label {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: rgba($parchment, 0.85);
+    }
+
+    select,
+    button {
+        background: rgba($stone, 0.8);
+        color: $parchment;
+        border: 1px solid rgba($rune-gold, 0.22);
+        border-radius: 8px;
+        padding: 8px 10px;
+    }
+
+    button {
+        margin-bottom: 4px;
+        cursor: pointer;
+    }
+}
+
+#inventory-message {
+    color: $mana;
+    min-height: 1.3rem;
+    margin: 0 0 12px;
+}
+
 #open-inventory,
 #close-inventory {
     background: linear-gradient(180deg, $rune-gold 0%, $rune-gold-dark 100%);
@@ -192,15 +224,37 @@ h1 {
 }
 
 #inventory-list {
-    list-style-type: none;
-    padding: 0;
     margin: 14px 0 18px;
 
-    li {
-        padding: 8px 10px;
-        background: rgba($stone, 0.7);
-        border: 1px solid rgba($rune-gold, 0.18);
-        border-radius: 8px;
-        margin-bottom: 8px;
+    .inventory-compartment {
+        margin-bottom: 14px;
+
+        h3 {
+            font-size: 0.82rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin: 0 0 8px;
+            color: rgba($parchment, 0.92);
+        }
+
+        ul {
+            list-style-type: none;
+            padding: 0;
+            margin: 0;
+        }
+
+        li {
+            padding: 8px 10px;
+            background: rgba($stone, 0.7);
+            border: 1px solid rgba($rune-gold, 0.18);
+            border-radius: 8px;
+            margin-bottom: 8px;
+            font-size: 0.88rem;
+        }
+
+        .empty-slot {
+            opacity: 0.72;
+            font-style: italic;
+        }
     }
 }

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -1,7 +1,33 @@
 // game.js
 
+const INVENTORY_COMPARTMENTS = {
+    back: { label: 'Back', maxWeight: 8, maxSpace: 6 },
+    belt: { label: 'Belt', maxWeight: 4, maxSpace: 4 },
+    hands: { label: 'Hands', maxWeight: 6, maxSpace: 2 }
+};
+
+const ITEM_CATALOG = {
+    Bow: { weight: 3, space: 2 },
+    Arrows: { weight: 1, space: 1 },
+    Dagger: { weight: 1, space: 1 },
+    'Healing Herbs': { weight: 1, space: 1 },
+    Backpack: {
+        weight: 2,
+        space: 2,
+        upgrade: {
+            compartment: 'back',
+            maxWeight: 6,
+            maxSpace: 4
+        }
+    }
+};
+
 const gameState = {
-    inventory: [],
+    inventory: {
+        back: [],
+        belt: [],
+        hands: []
+    },
     stats: {
         strength: 10,
         endurance: 10,
@@ -11,21 +37,142 @@ const gameState = {
     }
 };
 
-function addToInventory(item) {
-    if (!gameState.inventory.includes(item)) {
-        gameState.inventory.push(item);
-        updateInventoryDisplay();
-        saveGame();
+function getItemData(itemName) {
+    return ITEM_CATALOG[itemName] || { weight: 1, space: 1 };
+}
+
+function getAllInventoryItems() {
+    return Object.values(gameState.inventory).flat();
+}
+
+function getCompartmentCapacity(compartment) {
+    const baseCapacity = INVENTORY_COMPARTMENTS[compartment];
+    const capacity = { ...baseCapacity };
+
+    getAllInventoryItems().forEach(item => {
+        if (item.upgrade?.compartment === compartment) {
+            capacity.maxWeight += item.upgrade.maxWeight;
+            capacity.maxSpace += item.upgrade.maxSpace;
+        }
+    });
+
+    return capacity;
+}
+
+function getCompartmentUsage(compartment) {
+    return gameState.inventory[compartment].reduce(
+        (usage, item) => {
+            usage.weight += item.weight;
+            usage.space += item.space;
+            return usage;
+        },
+        { weight: 0, space: 0 }
+    );
+}
+
+function canAddItemToCompartment(itemData, compartment) {
+    const capacity = getCompartmentCapacity(compartment);
+    const usage = getCompartmentUsage(compartment);
+
+    return {
+        fitsWeight: usage.weight + itemData.weight <= capacity.maxWeight,
+        fitsSpace: usage.space + itemData.space <= capacity.maxSpace
+    };
+}
+
+function addToInventory(itemName, preferredCompartment = 'back') {
+    const itemData = getItemData(itemName);
+    const item = { name: itemName, ...itemData };
+
+    const compartmentsToTry = [
+        preferredCompartment,
+        ...Object.keys(INVENTORY_COMPARTMENTS).filter(compartment => compartment !== preferredCompartment)
+    ];
+
+    const fittingCompartment = compartmentsToTry.find(compartment => {
+        const fitCheck = canAddItemToCompartment(item, compartment);
+        return fitCheck.fitsWeight && fitCheck.fitsSpace;
+    });
+
+    if (!fittingCompartment) {
+        setInventoryMessage(`No room for ${itemName}. It exceeds space or weight limits.`);
+        return false;
     }
+
+    gameState.inventory[fittingCompartment].push(item);
+    setInventoryMessage(`${itemName} added to ${INVENTORY_COMPARTMENTS[fittingCompartment].label}.`);
+    updateInventoryDisplay();
+    saveGame();
+    return true;
+}
+
+function setInventoryMessage(message) {
+    const messageElement = document.getElementById('inventory-message');
+    if (messageElement) {
+        messageElement.textContent = message;
+    }
+}
+
+function updateInventoryItemSelect() {
+    const itemSelect = document.getElementById('inventory-item-select');
+
+    if (!itemSelect) {
+        return;
+    }
+
+    itemSelect.innerHTML = '';
+
+    Object.entries(ITEM_CATALOG).forEach(([itemName, itemData]) => {
+        const option = document.createElement('option');
+        option.value = itemName;
+        option.textContent = `${itemName} (W:${itemData.weight}, S:${itemData.space})`;
+        itemSelect.appendChild(option);
+    });
 }
 
 function updateInventoryDisplay() {
     const inventoryList = document.getElementById('inventory-list');
+
+    if (!inventoryList) {
+        return;
+    }
+
     inventoryList.innerHTML = '';
-    gameState.inventory.forEach(item => {
-        const li = document.createElement('li');
-        li.textContent = item;
-        inventoryList.appendChild(li);
+
+    Object.keys(INVENTORY_COMPARTMENTS).forEach(compartment => {
+        const capacity = getCompartmentCapacity(compartment);
+        const usage = getCompartmentUsage(compartment);
+
+        const section = document.createElement('section');
+        section.className = 'inventory-compartment';
+
+        const heading = document.createElement('h3');
+        heading.textContent = `${INVENTORY_COMPARTMENTS[compartment].label} (${usage.space}/${capacity.maxSpace} space, ${usage.weight}/${capacity.maxWeight} weight)`;
+        section.appendChild(heading);
+
+        const list = document.createElement('ul');
+
+        if (gameState.inventory[compartment].length === 0) {
+            const emptyItem = document.createElement('li');
+            emptyItem.textContent = 'Empty';
+            emptyItem.className = 'empty-slot';
+            list.appendChild(emptyItem);
+        } else {
+            gameState.inventory[compartment].forEach(item => {
+                const listItem = document.createElement('li');
+                let label = `${item.name} (W:${item.weight}, S:${item.space})`;
+
+                if (item.upgrade) {
+                    label += ' • expands carrying capacity';
+                }
+
+                listItem.textContent = label;
+                list.appendChild(listItem);
+            });
+        }
+
+        section.appendChild(list);
+        inventoryList.appendChild(section);
     });
 }
 
@@ -48,8 +195,8 @@ function updateStatsDisplay() {
 }
 
 function modifyStat(stat, amount) {
-    if (gameState.stats.hasOwnProperty(stat)) {
-        gameState.stats[stat] += amount;
+    if (Object.prototype.hasOwnProperty.call(gameState.stats, stat)) {
+        gameState.stats[stat] = Math.max(0, gameState.stats[stat] + amount);
         updateStatsDisplay();
         saveGame();
     }
@@ -59,23 +206,47 @@ function saveGame() {
     localStorage.setItem('gameState', JSON.stringify(gameState));
 }
 
+function migrateLegacyInventory(legacyInventory) {
+    if (!Array.isArray(legacyInventory)) {
+        return { back: [], belt: [], hands: [] };
+    }
+
+    const migrated = { back: [], belt: [], hands: [] };
+
+    legacyInventory.forEach(itemName => {
+        const itemData = getItemData(itemName);
+        migrated.back.push({ name: itemName, ...itemData });
+    });
+
+    return migrated;
+}
+
 function loadGame() {
     const savedState = localStorage.getItem('gameState');
+
     if (savedState) {
         const loadedState = JSON.parse(savedState);
-        gameState.inventory = loadedState.inventory || [];
+
+        if (Array.isArray(loadedState.inventory)) {
+            gameState.inventory = migrateLegacyInventory(loadedState.inventory);
+        } else {
+            gameState.inventory = loadedState.inventory || gameState.inventory;
+        }
+
         gameState.stats = loadedState.stats || gameState.stats;
-        updateInventoryDisplay();
-        updateStatsDisplay();
     }
+
+    updateInventoryItemSelect();
+    updateInventoryDisplay();
+    updateStatsDisplay();
 }
 
 function handle404() {
-    if (document.title.includes("Lost in the Void")) {
-        console.log("Player encountered a 404 error");
+    if (document.title.includes('Lost in the Void')) {
+        console.log('Player encountered a 404 error');
         document.body.style.opacity = 0;
         setTimeout(() => {
-            document.body.style.transition = "opacity 2s";
+            document.body.style.transition = 'opacity 2s';
             document.body.style.opacity = 1;
         }, 100);
     }
@@ -85,6 +256,7 @@ function setupInventoryPopup() {
     const openBtn = document.getElementById('open-inventory');
     const closeBtn = document.getElementById('close-inventory');
     const popup = document.getElementById('inventory-popup');
+    const addForm = document.getElementById('inventory-add-form');
 
     openBtn.addEventListener('click', () => {
         popup.classList.add('show');
@@ -94,10 +266,19 @@ function setupInventoryPopup() {
         popup.classList.remove('show');
     });
 
-    document.addEventListener('keydown', (event) => {
+    document.addEventListener('keydown', event => {
         if (event.key === 'Escape') {
             popup.classList.remove('show');
         }
+    });
+
+    addForm.addEventListener('submit', event => {
+        event.preventDefault();
+
+        const itemName = document.getElementById('inventory-item-select').value;
+        const compartment = document.getElementById('inventory-compartment-select').value;
+
+        addToInventory(itemName, compartment);
     });
 }
 
@@ -105,8 +286,7 @@ document.addEventListener('DOMContentLoaded', function() {
     loadGame();
     handle404();
     setupInventoryPopup();
-    
-    // Add click event listeners to choice links
+
     document.querySelectorAll('#choices a').forEach(link => {
         link.addEventListener('click', function(e) {
             e.preventDefault();

--- a/scenes/check_gear.html
+++ b/scenes/check_gear.html
@@ -6,7 +6,7 @@ choices:
     next_scene: forest
 ---
 
-You inspect your gear. You have a bow, a quiver of arrows, a small dagger, and a pouch of healing herbs.
+You inspect your gear. You have a bow, a quiver of arrows, a small dagger, a pouch of healing herbs, and a worn but sturdy backpack.
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {
@@ -14,5 +14,6 @@ document.addEventListener('DOMContentLoaded', function() {
     addToInventory("Arrows");
     addToInventory("Dagger");
     addToInventory("Healing Herbs");
+    addToInventory("Backpack", "back");
 });
 </script>


### PR DESCRIPTION
### Motivation

- Replace a flat inventory list with a compartmentalized system that tracks weight and space limits per compartment.
- Provide a simple in-UI way to add items and show messages when items cannot be added due to capacity.
- Support item definitions with weights/space and upgrades (e.g., `Backpack`) and migrate legacy flat inventories to the new shape.

### Description

- Update markup in `_includes/inventory_popup.html` to add an `#inventory-add-form` with item and compartment `select`s, an `#inventory-message` element, and change `#inventory-list` to a compartmentalized display section.
- Add styling in `assets/css/main.scss` for the new form, message, and compartment list layout including `.inventory-compartment` and `.empty-slot` rules.
- Implement inventory system changes in `assets/js/game.js` including `INVENTORY_COMPARTMENTS` and `ITEM_CATALOG`, change `gameState.inventory` to an object with `back`, `belt`, and `hands` arrays, and add functions for capacity/usage checks (`getCompartmentCapacity`, `getCompartmentUsage`, `canAddItemToCompartment`), item addition with compartment fallback (`addToInventory`), UI helpers (`updateInventoryItemSelect`, `setInventoryMessage`, `updateInventoryDisplay`), and legacy migration (`migrateLegacyInventory`).
- Wire up the inventory add form submission and popup behavior in `setupInventoryPopup`, enhance `loadGame` to migrate legacy inventories and initialize the item select, and add a safety check to `modifyStat` to clamp stats to `>= 0`.
- Update `scenes/check_gear.html` to add a `Backpack` to the starting gear and insert it into the new inventory format with `addToInventory("Backpack", "back")`.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac033c8d488320b707bafef0c53363)