### PR TITLE
Add hierarchical skill tree pop-in to character profile

### DIFF
--- a/_includes/character_stats.html
+++ b/_includes/character_stats.html
@@ -1,5 +1,8 @@
 <header id="character-stats">
-    <h2>Heroic Attributes</h2>
+    <div class="character-stats-heading">
+        <h2>Heroic Attributes</h2>
+        <button id="open-skills" type="button">Open Skills</button>
+    </div>
     <div id="stats-container">
         <div class="stat">
             <div class="stat-heading">
@@ -38,3 +41,12 @@
         </div>
     </div>
 </header>
+
+<div id="skills-popup" class="popup">
+    <div class="popup-content">
+        <h2>Skill Tree</h2>
+        <p class="skill-tree-helper">From broad disciplines to specialized techniques.</p>
+        <div id="skills-tree"></div>
+        <button id="close-skills" type="button">Close</button>
+    </div>
+</div>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -38,6 +38,17 @@ body {
         font-size: 1rem;
     }
 
+    .character-stats-heading {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+
+        h2 {
+            margin: 0;
+        }
+    }
+
     #stats-container {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(155px, 1fr));
@@ -148,6 +159,21 @@ h1 {
     display: block;
 }
 
+#skills-popup {
+    left: auto;
+    right: 0;
+    transform: translateX(105%);
+
+    .popup-content {
+        border-right: 0;
+        border-left: 1px solid rgba($rune-gold, 0.35);
+    }
+
+    &.show {
+        transform: translateX(0);
+    }
+}
+
 .popup.show {
     transform: translateX(0);
 }
@@ -199,7 +225,9 @@ h1 {
 }
 
 #open-inventory,
-#close-inventory {
+#close-inventory,
+#open-skills,
+#close-skills {
     background: linear-gradient(180deg, $rune-gold 0%, $rune-gold-dark 100%);
     color: #191210;
     border: 1px solid rgba(#f5d689, 0.5);
@@ -221,6 +249,71 @@ h1 {
     top: 22px;
     left: 24px;
     z-index: 220;
+}
+
+#open-skills {
+    position: static;
+    padding: 8px 12px;
+    font-size: 0.75rem;
+}
+
+#skills-tree {
+    margin: 14px 0 18px;
+
+    .skills-list {
+        list-style: none;
+        margin: 0;
+        padding-left: 0;
+    }
+
+    > .skills-list-general {
+        display: grid;
+        gap: 10px;
+    }
+
+    .skill-general,
+    .skill-branch,
+    .skill-specific {
+        padding: 7px 10px;
+        border-radius: 8px;
+        border: 1px solid rgba($rune-gold, 0.2);
+    }
+
+    .skill-general {
+        background: rgba($stone, 0.74);
+        font-weight: 700;
+    }
+
+    .skills-list-branch {
+        margin-top: 8px;
+        padding-left: 14px;
+        display: grid;
+        gap: 8px;
+    }
+
+    .skill-branch {
+        background: rgba(31, 44, 70, 0.52);
+        font-weight: 600;
+    }
+
+    .skills-list-specific {
+        margin-top: 8px;
+        padding-left: 14px;
+        display: grid;
+        gap: 6px;
+    }
+
+    .skill-specific {
+        background: rgba(20, 20, 33, 0.72);
+        font-weight: 400;
+        font-size: 0.86rem;
+    }
+}
+
+.skill-tree-helper {
+    margin: 0;
+    color: rgba($parchment, 0.8);
+    font-size: 0.86rem;
 }
 
 #inventory-list {

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -22,6 +22,30 @@ const ITEM_CATALOG = {
     }
 };
 
+const SKILL_TREE = [
+    {
+        name: 'Combat',
+        branches: [
+            { name: 'Melee', skills: ['Swordplay', 'Shield Bash', 'Riposte'] },
+            { name: 'Ranged', skills: ['Longbow Aim', 'Quick Draw', 'Piercing Shot'] }
+        ]
+    },
+    {
+        name: 'Survival',
+        branches: [
+            { name: 'Tracking', skills: ['Trail Reading', 'Scent Marking', 'Silent Pursuit'] },
+            { name: 'Fieldcraft', skills: ['Camp Setup', 'Foraging', 'Herbal Remedy'] }
+        ]
+    },
+    {
+        name: 'Mysticism',
+        branches: [
+            { name: 'Runes', skills: ['Glyph Etching', 'Ward Sigils', 'Resonance Binding'] },
+            { name: 'Mind Arts', skills: ['Focus Trance', 'Echo Sense', 'Spirit Lure'] }
+        ]
+    }
+];
+
 const gameState = {
     inventory: {
         back: [],
@@ -194,6 +218,58 @@ function updateStatsDisplay() {
     }
 }
 
+function updateSkillsDisplay() {
+    const skillsTreeElement = document.getElementById('skills-tree');
+
+    if (!skillsTreeElement) {
+        return;
+    }
+
+    skillsTreeElement.innerHTML = '';
+
+    const rootList = document.createElement('ul');
+    rootList.className = 'skills-list skills-list-general';
+
+    SKILL_TREE.forEach(generalSkill => {
+        const generalItem = document.createElement('li');
+        generalItem.className = 'skill-general';
+
+        const generalLabel = document.createElement('span');
+        generalLabel.textContent = generalSkill.name;
+        generalItem.appendChild(generalLabel);
+
+        const branchList = document.createElement('ul');
+        branchList.className = 'skills-list skills-list-branch';
+
+        generalSkill.branches.forEach(branch => {
+            const branchItem = document.createElement('li');
+            branchItem.className = 'skill-branch';
+
+            const branchLabel = document.createElement('span');
+            branchLabel.textContent = branch.name;
+            branchItem.appendChild(branchLabel);
+
+            const specificList = document.createElement('ul');
+            specificList.className = 'skills-list skills-list-specific';
+
+            branch.skills.forEach(specificSkill => {
+                const specificItem = document.createElement('li');
+                specificItem.className = 'skill-specific';
+                specificItem.textContent = specificSkill;
+                specificList.appendChild(specificItem);
+            });
+
+            branchItem.appendChild(specificList);
+            branchList.appendChild(branchItem);
+        });
+
+        generalItem.appendChild(branchList);
+        rootList.appendChild(generalItem);
+    });
+
+    skillsTreeElement.appendChild(rootList);
+}
+
 function modifyStat(stat, amount) {
     if (Object.prototype.hasOwnProperty.call(gameState.stats, stat)) {
         gameState.stats[stat] = Math.max(0, gameState.stats[stat] + amount);
@@ -239,6 +315,7 @@ function loadGame() {
     updateInventoryItemSelect();
     updateInventoryDisplay();
     updateStatsDisplay();
+    updateSkillsDisplay();
 }
 
 function handle404() {
@@ -282,10 +359,35 @@ function setupInventoryPopup() {
     });
 }
 
+function setupSkillsPopup() {
+    const openBtn = document.getElementById('open-skills');
+    const closeBtn = document.getElementById('close-skills');
+    const popup = document.getElementById('skills-popup');
+
+    if (!openBtn || !closeBtn || !popup) {
+        return;
+    }
+
+    openBtn.addEventListener('click', () => {
+        popup.classList.add('show');
+    });
+
+    closeBtn.addEventListener('click', () => {
+        popup.classList.remove('show');
+    });
+
+    document.addEventListener('keydown', event => {
+        if (event.key === 'Escape') {
+            popup.classList.remove('show');
+        }
+    });
+}
+
 document.addEventListener('DOMContentLoaded', function() {
     loadGame();
     handle404();
     setupInventoryPopup();
+    setupSkillsPopup();
 
     document.querySelectorAll('#choices a').forEach(link => {
         link.addEventListener('click', function(e) {


### PR DESCRIPTION
### Motivation
- Surface a hierarchical skills list in the character profile so players can inspect a three-level skill hierarchy (general → branch → specific) directly from the UI. 
- Provide a compact, themed pop-in panel to keep the main layout uncluttered while exposing skills on demand.

### Description
- Added an `Open Skills` button and a right-side pop-in container to the character profile include in `_includes/character_stats.html` that hosts the skill tree (`#open-skills`, `#skills-popup`, `#skills-tree`).
- Introduced a structured `SKILL_TREE` dataset and a renderer `updateSkillsDisplay()` in `assets/js/game.js` that builds the three-level hierarchy and injects it into the popup, and added `setupSkillsPopup()` to manage open/close behavior (including Escape key handling) and wired it into initialization.
- Updated `assets/css/main.scss` with styles for the new header layout, right-side skills popup, shared skill buttons, and nested skill-tree visuals to match the existing theme.

### Testing
- Ran `node --check assets/js/game.js` to validate JavaScript syntax and it succeeded.
- Attempted `bundle exec jekyll build` to validate site build but it failed because the environment lacks a `Gemfile` (not present in this repo), so a full Jekyll build could not be performed.
- Attempted automated browser rendering/screenshot (Playwright) while serving the site with `python3 -m http.server`, but the scripted screenshot timed out; the UI was exercised locally via the dev server attempt but the Playwright run did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac3d96b3048320b6ffa60690c40112)