### PR TITLE
Improve popup UX: edge-hover panels, scrollable skill tree, and in-app glide alerts

### DIFF
--- a/_includes/character_stats.html
+++ b/_includes/character_stats.html
@@ -1,7 +1,6 @@
 <header id="character-stats">
     <div class="character-stats-heading">
         <h2>Heroic Attributes</h2>
-        <button id="open-skills" type="button">Open Skills</button>
     </div>
     <div id="stats-container">
         <div class="stat">
@@ -47,6 +46,5 @@
         <h2>Skill Tree</h2>
         <p class="skill-tree-helper">From broad disciplines to specialized techniques.</p>
         <div id="skills-tree"></div>
-        <button id="close-skills" type="button">Close</button>
     </div>
 </div>

--- a/_includes/inventory_popup.html
+++ b/_includes/inventory_popup.html
@@ -17,7 +17,5 @@
 
         <p id="inventory-message" aria-live="polite"></p>
         <div id="inventory-list"></div>
-        <button id="close-inventory">Close</button>
     </div>
 </div>
-<button id="open-inventory">Open Inventory</button>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -180,6 +180,7 @@ h1 {
 
 .popup-content {
     height: 100%;
+    overflow: hidden;
     background: linear-gradient(180deg, #20182f 0%, #120e1d 100%);
     border-right: 1px solid rgba($rune-gold, 0.35);
     padding: 22px;
@@ -224,41 +225,21 @@ h1 {
     margin: 0 0 12px;
 }
 
-#open-inventory,
-#close-inventory,
-#open-skills,
-#close-skills {
-    background: linear-gradient(180deg, $rune-gold 0%, $rune-gold-dark 100%);
-    color: #191210;
-    border: 1px solid rgba(#f5d689, 0.5);
-    padding: 10px 16px;
-    cursor: pointer;
-    border-radius: 8px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    transition: filter 0.2s ease;
-
-    &:hover {
-        filter: brightness(1.08);
-    }
-}
-
-#open-inventory {
-    position: fixed;
-    top: 22px;
-    left: 24px;
-    z-index: 220;
-}
-
-#open-skills {
-    position: static;
-    padding: 8px 12px;
-    font-size: 0.75rem;
-}
 
 #skills-tree {
     margin: 14px 0 18px;
+    max-height: calc(100vh - 140px);
+    overflow-y: auto;
+    padding-right: 8px;
+
+    &::-webkit-scrollbar {
+        width: 8px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background: rgba($rune-gold, 0.45);
+        border-radius: 999px;
+    }
 
     .skills-list {
         list-style: none;
@@ -307,6 +288,17 @@ h1 {
         background: rgba(20, 20, 33, 0.72);
         font-weight: 400;
         font-size: 0.86rem;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+    }
+
+    .skill-level {
+        color: $rune-gold;
+        font-size: 0.78rem;
+        font-weight: 700;
+        white-space: nowrap;
     }
 }
 
@@ -350,4 +342,42 @@ h1 {
             font-style: italic;
         }
     }
+}
+
+
+#game-toast-container {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    z-index: 500;
+    display: grid;
+    gap: 10px;
+    pointer-events: none;
+}
+
+.game-toast {
+    min-width: 220px;
+    max-width: min(360px, 80vw);
+    padding: 10px 14px;
+    border-radius: 10px;
+    border: 1px solid rgba($rune-gold, 0.28);
+    background: linear-gradient(180deg, rgba(34, 24, 49, 0.97) 0%, rgba(17, 12, 26, 0.97) 100%);
+    color: $parchment;
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+    transform: translateX(120%);
+    opacity: 0;
+    transition: transform 0.34s ease, opacity 0.34s ease;
+}
+
+.game-toast.show {
+    transform: translateX(0);
+    opacity: 1;
+}
+
+.game-toast-success {
+    border-color: rgba($mana, 0.6);
+}
+
+.game-toast-warning {
+    border-color: rgba($ember, 0.55);
 }

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -26,22 +26,64 @@ const SKILL_TREE = [
     {
         name: 'Combat',
         branches: [
-            { name: 'Melee', skills: ['Swordplay', 'Shield Bash', 'Riposte'] },
-            { name: 'Ranged', skills: ['Longbow Aim', 'Quick Draw', 'Piercing Shot'] }
+            {
+                name: 'Melee',
+                skills: [
+                    { name: 'Swordplay', level: 4 },
+                    { name: 'Shield Bash', level: 3 },
+                    { name: 'Riposte', level: 2 }
+                ]
+            },
+            {
+                name: 'Ranged',
+                skills: [
+                    { name: 'Longbow Aim', level: 5 },
+                    { name: 'Quick Draw', level: 3 },
+                    { name: 'Piercing Shot', level: 4 }
+                ]
+            }
         ]
     },
     {
         name: 'Survival',
         branches: [
-            { name: 'Tracking', skills: ['Trail Reading', 'Scent Marking', 'Silent Pursuit'] },
-            { name: 'Fieldcraft', skills: ['Camp Setup', 'Foraging', 'Herbal Remedy'] }
+            {
+                name: 'Tracking',
+                skills: [
+                    { name: 'Trail Reading', level: 4 },
+                    { name: 'Scent Marking', level: 2 },
+                    { name: 'Silent Pursuit', level: 3 }
+                ]
+            },
+            {
+                name: 'Fieldcraft',
+                skills: [
+                    { name: 'Camp Setup', level: 4 },
+                    { name: 'Foraging', level: 5 },
+                    { name: 'Herbal Remedy', level: 3 }
+                ]
+            }
         ]
     },
     {
         name: 'Mysticism',
         branches: [
-            { name: 'Runes', skills: ['Glyph Etching', 'Ward Sigils', 'Resonance Binding'] },
-            { name: 'Mind Arts', skills: ['Focus Trance', 'Echo Sense', 'Spirit Lure'] }
+            {
+                name: 'Runes',
+                skills: [
+                    { name: 'Glyph Etching', level: 2 },
+                    { name: 'Ward Sigils', level: 3 },
+                    { name: 'Resonance Binding', level: 1 }
+                ]
+            },
+            {
+                name: 'Mind Arts',
+                skills: [
+                    { name: 'Focus Trance', level: 4 },
+                    { name: 'Echo Sense', level: 5 },
+                    { name: 'Spirit Lure', level: 2 }
+                ]
+            }
         ]
     }
 ];
@@ -104,6 +146,35 @@ function canAddItemToCompartment(itemData, compartment) {
     };
 }
 
+function showGlideAlert(message, type = 'info') {
+    const containerId = 'game-toast-container';
+    let container = document.getElementById(containerId);
+
+    if (!container) {
+        container = document.createElement('div');
+        container.id = containerId;
+        container.setAttribute('aria-live', 'polite');
+        container.setAttribute('aria-atomic', 'true');
+        document.body.appendChild(container);
+    }
+
+    const toast = document.createElement('div');
+    toast.className = `game-toast game-toast-${type}`;
+    toast.textContent = message;
+    container.appendChild(toast);
+
+    requestAnimationFrame(() => {
+        toast.classList.add('show');
+    });
+
+    setTimeout(() => {
+        toast.classList.remove('show');
+        setTimeout(() => {
+            toast.remove();
+        }, 340);
+    }, 2500);
+}
+
 function addToInventory(itemName, preferredCompartment = 'back') {
     const itemData = getItemData(itemName);
     const item = { name: itemName, ...itemData };
@@ -120,11 +191,13 @@ function addToInventory(itemName, preferredCompartment = 'back') {
 
     if (!fittingCompartment) {
         setInventoryMessage(`No room for ${itemName}. It exceeds space or weight limits.`);
+        showGlideAlert(`No room for ${itemName}.`, 'warning');
         return false;
     }
 
     gameState.inventory[fittingCompartment].push(item);
     setInventoryMessage(`${itemName} added to ${INVENTORY_COMPARTMENTS[fittingCompartment].label}.`);
+    showGlideAlert(`${itemName} added to ${INVENTORY_COMPARTMENTS[fittingCompartment].label}.`, 'success');
     updateInventoryDisplay();
     saveGame();
     return true;
@@ -255,7 +328,16 @@ function updateSkillsDisplay() {
             branch.skills.forEach(specificSkill => {
                 const specificItem = document.createElement('li');
                 specificItem.className = 'skill-specific';
-                specificItem.textContent = specificSkill;
+
+                const specificName = document.createElement('span');
+                specificName.textContent = specificSkill.name;
+
+                const specificLevel = document.createElement('span');
+                specificLevel.className = 'skill-level';
+                specificLevel.textContent = `Lvl ${specificSkill.level}/6`;
+
+                specificItem.appendChild(specificName);
+                specificItem.appendChild(specificLevel);
                 specificList.appendChild(specificItem);
             });
 
@@ -329,24 +411,44 @@ function handle404() {
     }
 }
 
-function setupInventoryPopup() {
-    const openBtn = document.getElementById('open-inventory');
-    const closeBtn = document.getElementById('close-inventory');
-    const popup = document.getElementById('inventory-popup');
-    const addForm = document.getElementById('inventory-add-form');
+function setupEdgePopups() {
+    const inventoryPopup = document.getElementById('inventory-popup');
+    const skillsPopup = document.getElementById('skills-popup');
 
-    openBtn.addEventListener('click', () => {
-        popup.classList.add('show');
-    });
+    if (!inventoryPopup || !skillsPopup) {
+        return;
+    }
 
-    closeBtn.addEventListener('click', () => {
-        popup.classList.remove('show');
+    document.addEventListener('mousemove', event => {
+        const edgeThreshold = 24;
+
+        if (event.clientX <= edgeThreshold) {
+            inventoryPopup.classList.add('show');
+        }
+
+        if (event.clientX >= window.innerWidth - edgeThreshold) {
+            skillsPopup.classList.add('show');
+        }
     });
 
     document.addEventListener('keydown', event => {
         if (event.key === 'Escape') {
-            popup.classList.remove('show');
+            inventoryPopup.classList.remove('show');
+            skillsPopup.classList.remove('show');
         }
+    });
+}
+
+function setupInventoryPopup() {
+    const popup = document.getElementById('inventory-popup');
+    const addForm = document.getElementById('inventory-add-form');
+
+    if (!popup || !addForm) {
+        return;
+    }
+
+    popup.addEventListener('mouseleave', () => {
+        popup.classList.remove('show');
     });
 
     addForm.addEventListener('submit', event => {
@@ -360,32 +462,21 @@ function setupInventoryPopup() {
 }
 
 function setupSkillsPopup() {
-    const openBtn = document.getElementById('open-skills');
-    const closeBtn = document.getElementById('close-skills');
     const popup = document.getElementById('skills-popup');
 
-    if (!openBtn || !closeBtn || !popup) {
+    if (!popup) {
         return;
     }
 
-    openBtn.addEventListener('click', () => {
-        popup.classList.add('show');
-    });
-
-    closeBtn.addEventListener('click', () => {
+    popup.addEventListener('mouseleave', () => {
         popup.classList.remove('show');
-    });
-
-    document.addEventListener('keydown', event => {
-        if (event.key === 'Escape') {
-            popup.classList.remove('show');
-        }
     });
 }
 
 document.addEventListener('DOMContentLoaded', function() {
     loadGame();
     handle404();
+    setupEdgePopups();
     setupInventoryPopup();
     setupSkillsPopup();
 
@@ -397,3 +488,5 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 });
+
+window.showGlideAlert = showGlideAlert;

--- a/scenes/find_dagger.html
+++ b/scenes/find_dagger.html
@@ -24,7 +24,7 @@ document.addEventListener('DOMContentLoaded', function() {
             if (this.textContent.includes('Take the dagger')) {
                 e.preventDefault();
                 addToInventory('Mysterious Dagger');
-                alert('You have added the Mysterious Dagger to your inventory!');
+                showGlideAlert('You have added the Mysterious Dagger to your inventory!', 'success');
                 window.location.href = 'take_dagger.html';
             }
         });

--- a/scenes/leave_dagger.html
+++ b/scenes/leave_dagger.html
@@ -15,6 +15,6 @@ You take one last look at the gleaming dagger before turning away. The weight of
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     modifyStat('wisdom', 1);
-    alert('Your wisdom has increased by 1!');
+    showGlideAlert('Your wisdom has increased by 1!', 'success');
 });
 </script>

--- a/scenes/take_dagger.html
+++ b/scenes/take_dagger.html
@@ -16,6 +16,6 @@ You carefully secure the dagger to your belt, feeling a little more prepared for
 document.addEventListener('DOMContentLoaded', function() {
     addToInventory("Dagger");
     modifyStat('dexterity', 1);
-    alert('Your dexterity has increased by 1!');
+    showGlideAlert('Your dexterity has increased by 1!', 'success');
 });
 </script>


### PR DESCRIPTION
### Motivation
- Replace blocking browser `alert()` calls with a visual, non-blocking in-app notification that matches the game UI.  
- Move away from explicit open/close buttons for inventory and skills toward a quicker edge-hover interaction to improve discoverability and flow.  
- Make the skills panel usable when its content overflows and show explicit skill levels for clarity.  

### Description
- Replaced all `alert()` usages with a new `showGlideAlert(message, type)` toast API and exposed it as `window.showGlideAlert`, and integrated it for inventory add/failure and scene notifications (changed files: `assets/js/game.js`, `scenes/*.html`).  
- Implemented edge-triggered popouts so moving the mouse to the left edge opens the inventory and moving to the right edge opens the skills panel via `setupEdgePopups()` (file: `assets/js/game.js`) and removed the old open/close buttons from the includes (`_includes/inventory_popup.html`, `_includes/character_stats.html`).  
- Added per-skill `level` (1–6) to the `SKILL_TREE` data model and updated the renderer to show `Lvl X/6` badges for each specific skill (file: `assets/js/game.js`).  
- Added scroll behavior and styled scrollbar for the skills panel and added toast styling to the global stylesheet (file: `assets/css/main.scss`).  

### Testing
- Ran `node --check assets/js/game.js` to validate JS syntax, which succeeded.  
- Performed automated UI validation with Playwright against a local server and captured a screenshot artifact showing the edge popouts and toast behavior, which completed successfully.  
- Attempted `jekyll build --trace` for a site build but `jekyll` was not available in the environment, so that check could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac6bf6770c832095efdb840ba09358)