### PR TITLE
Fix SCSS build failure caused by undefined `$health` variable

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -354,7 +354,7 @@ h1 {
         .inventory-discard-btn {
             background: rgba(72, 27, 27, 0.7);
             color: $parchment;
-            border: 1px solid rgba($health, 0.35);
+            border: 1px solid rgba($ember, 0.35);
             border-radius: 6px;
             padding: 4px 8px;
             font-size: 0.76rem;


### PR DESCRIPTION
### Motivation
- The Jekyll build failed with `Error: Undefined variable: "$health"` because the stylesheet referenced a non-existent SCSS variable in the inventory discard button border.

### Description
- Replaced the undefined variable in `assets/css/main.scss` by changing `border: 1px solid rgba($health, 0.35);` to `border: 1px solid rgba($ember, 0.35);` to use an existing color variable.

### Testing
- Confirmed no remaining references with `rg "\$health" assets/css/main.scss` which returned none; this check passed.
- Attempted `bundle exec jekyll build` but it could not be run in this environment because the repository `Gemfile`/Bundler setup is not available; this check failed due to environment constraints.
- Served the site with `python3 -m http.server 8000` and captured a visual verification screenshot via Playwright which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac75c51e248320a58a24e005d10e4e)