### PR TITLE
Inventory UX: add Armour compartment, keep popup open, enforce backpack placement, and add scrollbar

### DIFF
--- a/_includes/inventory_popup.html
+++ b/_includes/inventory_popup.html
@@ -10,6 +10,7 @@
                 <option value="back">Back</option>
                 <option value="belt">Belt</option>
                 <option value="hands">Hands</option>
+                <option value="armour">Armour</option>
             </select>
 
             <button type="submit">Add Item</button>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -310,6 +310,18 @@ h1 {
 
 #inventory-list {
     margin: 14px 0 18px;
+    max-height: calc(100vh - 240px);
+    overflow-y: auto;
+    padding-right: 6px;
+
+    &::-webkit-scrollbar {
+        width: 8px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background: rgba($rune-gold, 0.45);
+        border-radius: 999px;
+    }
 
     .inventory-summary {
         margin: 0 0 14px;

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -3,7 +3,8 @@
 const INVENTORY_COMPARTMENTS = {
     back: { label: 'Back', maxWeight: 8, maxSpace: 6 },
     belt: { label: 'Belt', maxWeight: 4, maxSpace: 4 },
-    hands: { label: 'Hands', maxWeight: 6, maxSpace: 2 }
+    hands: { label: 'Hands', maxWeight: 6, maxSpace: 2 },
+    armour: { label: 'Armour', maxWeight: 10, maxSpace: 6 }
 };
 
 const ITEM_CATALOG = {
@@ -14,6 +15,7 @@ const ITEM_CATALOG = {
     Backpack: {
         weight: 2,
         space: 2,
+        requiredCompartment: 'back',
         upgrade: {
             compartment: 'back',
             maxWeight: 6,
@@ -92,7 +94,8 @@ const gameState = {
     inventory: {
         back: [],
         belt: [],
-        hands: []
+        hands: [],
+        armour: []
     },
     stats: {
         strength: 10,
@@ -203,26 +206,19 @@ function addToInventory(itemName, preferredCompartment = 'back') {
 
     const itemData = getItemData(itemName);
     const item = { id: generateItemId(), name: itemName, ...itemData };
+    const targetCompartment = item.requiredCompartment || preferredCompartment;
 
-    const compartmentsToTry = [
-        preferredCompartment,
-        ...Object.keys(INVENTORY_COMPARTMENTS).filter(compartment => compartment !== preferredCompartment)
-    ];
+    const fitCheck = canAddItemToCompartment(item, targetCompartment);
 
-    const fittingCompartment = compartmentsToTry.find(compartment => {
-        const fitCheck = canAddItemToCompartment(item, compartment);
-        return fitCheck.fitsWeight && fitCheck.fitsSpace && fitCheck.fitsStrength;
-    });
-
-    if (!fittingCompartment) {
-        setInventoryMessage(`No room for ${itemName}. It exceeds space, compartment weight, or strength limits.`);
-        showGlideAlert(`No room for ${itemName}.`, 'warning');
+    if (!(fitCheck.fitsWeight && fitCheck.fitsSpace && fitCheck.fitsStrength)) {
+        setInventoryMessage(`No room for ${itemName} in ${INVENTORY_COMPARTMENTS[targetCompartment].label}.`);
+        showGlideAlert(`No room for ${itemName} in ${INVENTORY_COMPARTMENTS[targetCompartment].label}.`, 'warning');
         return false;
     }
 
-    gameState.inventory[fittingCompartment].push(item);
-    setInventoryMessage(`${itemName} added to ${INVENTORY_COMPARTMENTS[fittingCompartment].label}.`);
-    showGlideAlert(`${itemName} added to ${INVENTORY_COMPARTMENTS[fittingCompartment].label}.`, 'success');
+    gameState.inventory[targetCompartment].push(item);
+    setInventoryMessage(`${itemName} added to ${INVENTORY_COMPARTMENTS[targetCompartment].label}.`);
+    showGlideAlert(`${itemName} added to ${INVENTORY_COMPARTMENTS[targetCompartment].label}.`, 'success');
     updateInventoryDisplay();
     saveGame();
     return true;
@@ -277,6 +273,15 @@ function moveItem(itemId, targetCompartment) {
     }
 
     const [item] = gameState.inventory[sourceCompartment].splice(itemIndex, 1);
+
+    if (item.requiredCompartment && targetCompartment !== item.requiredCompartment) {
+        gameState.inventory[sourceCompartment].splice(itemIndex, 0, item);
+        setInventoryMessage(`${item.name} must stay in ${INVENTORY_COMPARTMENTS[item.requiredCompartment].label}.`);
+        showGlideAlert(`${item.name} must stay in ${INVENTORY_COMPARTMENTS[item.requiredCompartment].label}.`, 'warning');
+        updateInventoryDisplay();
+        return false;
+    }
+
     const fitCheck = canAddItemToCompartment(item, targetCompartment);
 
     if (!(fitCheck.fitsWeight && fitCheck.fitsSpace && fitCheck.fitsStrength)) {
@@ -494,10 +499,10 @@ function saveGame() {
 
 function migrateLegacyInventory(legacyInventory) {
     if (!Array.isArray(legacyInventory)) {
-        return { back: [], belt: [], hands: [] };
+        return { back: [], belt: [], hands: [], armour: [] };
     }
 
-    const migrated = { back: [], belt: [], hands: [] };
+    const migrated = { back: [], belt: [], hands: [], armour: [] };
 
     legacyInventory.forEach(itemName => {
         const itemData = getItemData(itemName);
@@ -519,7 +524,7 @@ function loadGame() {
             gameState.inventory = loadedState.inventory || gameState.inventory;
         }
 
-        Object.keys(gameState.inventory).forEach(compartment => {
+        Object.keys(INVENTORY_COMPARTMENTS).forEach(compartment => {
             gameState.inventory[compartment] = (gameState.inventory[compartment] || []).map(item => ({
                 id: item.id || generateItemId(),
                 ...item
@@ -577,20 +582,31 @@ function setupEdgePopups() {
 function setupInventoryPopup() {
     const popup = document.getElementById('inventory-popup');
     const addForm = document.getElementById('inventory-add-form');
+    const itemSelect = document.getElementById('inventory-item-select');
+    const compartmentSelect = document.getElementById('inventory-compartment-select');
 
-    if (!popup || !addForm) {
+    if (!popup || !addForm || !itemSelect || !compartmentSelect) {
         return;
     }
 
-    popup.addEventListener('mouseleave', () => {
-        popup.classList.remove('show');
+    itemSelect.addEventListener('change', () => {
+        const selectedItemData = getItemData(itemSelect.value);
+
+        if (selectedItemData.requiredCompartment) {
+            compartmentSelect.value = selectedItemData.requiredCompartment;
+        }
     });
 
     addForm.addEventListener('submit', event => {
         event.preventDefault();
 
-        const itemName = document.getElementById('inventory-item-select').value;
-        const compartment = document.getElementById('inventory-compartment-select').value;
+        const itemName = itemSelect.value;
+        const selectedItemData = getItemData(itemName);
+        const compartment = selectedItemData.requiredCompartment || compartmentSelect.value;
+
+        if (selectedItemData.requiredCompartment) {
+            compartmentSelect.value = selectedItemData.requiredCompartment;
+        }
 
         addToInventory(itemName, compartment);
     });


### PR DESCRIPTION
### Motivation
- Improve inventory usability by adding an "Armour" category so players can store armor separately.
- Prevent the inventory popup from closing during interaction so players can drag/drop and move items without the UI closing unexpectedly.
- Ensure items that must be equipped in a specific slot (like `Backpack`) cannot be placed or moved to invalid compartments.
- Make large inventories usable on small screens by adding a scrollbar to the inventory list area.

### Description
- Added an `Armour` option to the compartment selector in `_includes/inventory_popup.html` and added an `armour` compartment to `INVENTORY_COMPARTMENTS` and `gameState.inventory` in `assets/js/game.js`.
- Introduced a `requiredCompartment` property on `ITEM_CATALOG.Backpack` and updated `addToInventory` to place items into the selected or required compartment only (no automatic fallback across compartments).
- Enforced `requiredCompartment` during drag/drop moves in `moveItem` so items like `Backpack` cannot be moved off the `Back` compartment.
- Updated migration/loading logic in `migrateLegacyInventory`/`loadGame` to initialize the new `armour` compartment safely for older saves and to iterate `Object.keys(INVENTORY_COMPARTMENTS)` when normalizing inventory entries.
- Kept the inventory popup open during interaction by removing the `mouseleave` auto-close for the inventory popup and added logic in `setupInventoryPopup` to synchronize the compartment selector with items that require a specific compartment.
- Added vertical overflow styling and a thin scrollbar for `#inventory-list` in `assets/css/main.scss` so long inventories can scroll.

### Testing
- Ran `node --check assets/js/game.js` to validate JavaScript syntax and it succeeded.
- Served the app with `python3 -m http.server 8000` and performed a visual verification using a Playwright script which captured a screenshot of the updated inventory popup, and the visual check completed successfully.
- Performed a local static check of diffs and ran the UI interaction flows in the browser session used for the screenshot to verify the new compartment, add, and move behaviors (visual verification succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac7f2a64148320a8f261faa6aaa7b5)