### PR TITLE
Add Dark Path forest troll combat encounter and weapon-based combat system

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -420,3 +420,56 @@ h1 {
 .game-toast-warning {
     border-color: rgba($ember, 0.55);
 }
+
+#combat-panel {
+    margin-top: 18px;
+    padding: 14px;
+    border-radius: 10px;
+    border: 1px solid rgba($rune-gold, 0.26);
+    background: rgba($stone, 0.62);
+
+    label {
+        display: block;
+        margin: 10px 0 6px;
+        font-size: 0.82rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+    }
+
+    select,
+    button {
+        background: rgba(19, 15, 29, 0.86);
+        color: $parchment;
+        border: 1px solid rgba($rune-gold, 0.3);
+        border-radius: 8px;
+        padding: 8px 10px;
+    }
+
+    button {
+        cursor: pointer;
+    }
+}
+
+.combat-actions {
+    display: flex;
+    gap: 10px;
+    margin-top: 12px;
+}
+
+#combat-status {
+    margin: 12px 0;
+    color: $rune-gold;
+    font-weight: 700;
+}
+
+#combat-log {
+    max-height: 210px;
+    overflow-y: auto;
+    border-top: 1px solid rgba($rune-gold, 0.22);
+    padding-top: 10px;
+
+    p {
+        margin: 0 0 8px;
+        font-size: 0.9rem;
+    }
+}

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -8,9 +8,27 @@ const INVENTORY_COMPARTMENTS = {
 };
 
 const ITEM_CATALOG = {
-    Bow: { weight: 3, space: 2 },
+    Bow: {
+        weight: 3,
+        space: 2,
+        combat: {
+            skill: 'Longbow Aim',
+            attackModifier: 1,
+            damage: [2, 6],
+            tags: ['ranged']
+        }
+    },
     Arrows: { weight: 1, space: 1 },
-    Dagger: { weight: 1, space: 1 },
+    Dagger: {
+        weight: 1,
+        space: 1,
+        combat: {
+            skill: 'Swordplay',
+            attackModifier: 2,
+            damage: [1, 6],
+            tags: ['light']
+        }
+    },
     'Healing Herbs': { weight: 1, space: 1 },
     Backpack: {
         weight: 2,
@@ -112,6 +130,80 @@ function generateItemId() {
 
 function getItemData(itemName) {
     return ITEM_CATALOG[itemName] || { weight: 1, space: 1 };
+}
+
+function rollDie(sides = 6) {
+    return Math.floor(Math.random() * sides) + 1;
+}
+
+function rollRange(min, max) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function getSkillLevel(skillName) {
+    if (!skillName) {
+        return 0;
+    }
+
+    for (const generalSkill of SKILL_TREE) {
+        for (const branch of generalSkill.branches) {
+            const match = branch.skills.find(skill => skill.name === skillName);
+            if (match) {
+                return match.level;
+            }
+        }
+    }
+
+    return 0;
+}
+
+function getCombatWeaponsFromInventory() {
+    return getAllInventoryItems()
+        .map(item => {
+            const catalogData = getItemData(item.name);
+            const combat = item.combat || catalogData.combat;
+
+            if (!combat) {
+                return null;
+            }
+
+            return {
+                ...item,
+                combat,
+                skillLevel: getSkillLevel(combat.skill)
+            };
+        })
+        .filter(Boolean);
+}
+
+function resolveAttackRound({
+    attackerSkill = 0,
+    attackerRandom = rollDie(10),
+    weaponAttackModifier = 0,
+    defenderDexterity = 0,
+    defenderRandom = rollDie(10),
+    defenderArmourModifier = 0,
+    damageRange = [1, 4]
+}) {
+    const attackRoll = attackerSkill + attackerRandom + weaponAttackModifier;
+    const defenceRoll = defenderDexterity + defenderRandom + defenderArmourModifier;
+    const hit = attackRoll > defenceRoll;
+    const damage = hit ? rollRange(damageRange[0], damageRange[1]) : 0;
+
+    return {
+        attackRoll,
+        defenceRoll,
+        hit,
+        damage,
+        details: {
+            attackerSkill,
+            attackerRandom,
+            weaponAttackModifier,
+            defenderDexterity,
+            defenderRandom,
+            defenderArmourModifier
+        }
+    };
 }
 
 function getAllInventoryItems() {

--- a/scenes/dark_path.html
+++ b/scenes/dark_path.html
@@ -1,0 +1,177 @@
+---
+layout: game
+title: The Dark Path
+---
+
+The darker path narrows into a shadow-choked corridor of ancient trees. A hulking forest troll drags itself from the undergrowth, blocking your way with a guttural roar.
+
+<div id="combat-panel">
+    <p><strong>Forest Troll Endurance:</strong> <span id="troll-endurance">18</span></p>
+    <p><strong>Your Endurance:</strong> <span id="hero-endurance"></span></p>
+    <label for="weapon-choice">Choose your weapon:</label>
+    <select id="weapon-choice"></select>
+    <div class="combat-actions">
+        <button type="button" id="attack-button">Attack</button>
+        <button type="button" id="flee-button">Flee</button>
+    </div>
+    <p id="combat-status" aria-live="polite"></p>
+    <div id="combat-log" aria-live="polite"></div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const foe = {
+        name: 'Forest Troll',
+        endurance: 18,
+        dexterity: 8,
+        armourModifier: 2,
+        attackSkill: 5,
+        weaponAttackModifier: 1,
+        damage: [2, 5]
+    };
+
+    const weaponChoice = document.getElementById('weapon-choice');
+    const attackButton = document.getElementById('attack-button');
+    const fleeButton = document.getElementById('flee-button');
+    const trollEndurance = document.getElementById('troll-endurance');
+    const heroEndurance = document.getElementById('hero-endurance');
+    const combatStatus = document.getElementById('combat-status');
+    const combatLog = document.getElementById('combat-log');
+
+    const heroArmourModifier = 0;
+    let combatEnded = false;
+
+    function appendLog(message) {
+        const entry = document.createElement('p');
+        entry.textContent = message;
+        combatLog.prepend(entry);
+    }
+
+    function renderWeapons() {
+        const weapons = getCombatWeaponsFromInventory();
+        weaponChoice.innerHTML = '';
+
+        if (weapons.length === 0) {
+            const fists = document.createElement('option');
+            fists.value = '__fists__';
+            fists.textContent = 'Bare Hands (Untrained)';
+            weaponChoice.appendChild(fists);
+            return;
+        }
+
+        weapons.forEach(weapon => {
+            const option = document.createElement('option');
+            option.value = weapon.id;
+            option.textContent = `${weapon.name} (Skill ${weapon.skillLevel}, +${weapon.combat.attackModifier} hit)`;
+            weaponChoice.appendChild(option);
+        });
+    }
+
+    function getSelectedWeapon() {
+        const chosen = weaponChoice.value;
+        const weapons = getCombatWeaponsFromInventory();
+        const selected = weapons.find(weapon => weapon.id === chosen);
+
+        if (selected) {
+            return selected;
+        }
+
+        return {
+            id: '__fists__',
+            name: 'Bare Hands',
+            skillLevel: 0,
+            combat: {
+                skill: null,
+                attackModifier: 0,
+                damage: [1, 3]
+            }
+        };
+    }
+
+    function updateDisplay() {
+        trollEndurance.textContent = foe.endurance;
+        heroEndurance.textContent = gameState.stats.endurance;
+    }
+
+    function endCombat(message, redirectTo) {
+        combatEnded = true;
+        attackButton.disabled = true;
+        fleeButton.disabled = true;
+        combatStatus.textContent = message;
+
+        if (redirectTo) {
+            setTimeout(() => {
+                window.location.href = `${redirectTo}.html`;
+            }, 1800);
+        }
+    }
+
+    attackButton.addEventListener('click', function() {
+        if (combatEnded) {
+            return;
+        }
+
+        const weapon = getSelectedWeapon();
+
+        const heroAttack = resolveAttackRound({
+            attackerSkill: weapon.skillLevel,
+            weaponAttackModifier: weapon.combat.attackModifier,
+            defenderDexterity: foe.dexterity,
+            defenderArmourModifier: foe.armourModifier,
+            damageRange: weapon.combat.damage
+        });
+
+        appendLog(`You attack with ${weapon.name}: ${heroAttack.attackRoll} vs ${foe.name} defence ${heroAttack.defenceRoll}.`);
+
+        if (heroAttack.hit) {
+            foe.endurance = Math.max(0, foe.endurance - heroAttack.damage);
+            appendLog(`Hit! ${weapon.name} deals ${heroAttack.damage} damage.`);
+        } else {
+            appendLog('Miss. The troll shrugs off your strike.');
+        }
+
+        updateDisplay();
+
+        if (foe.endurance <= 0) {
+            endCombat('The forest troll collapses unconscious. You are victorious.', 'forest');
+            return;
+        }
+
+        const foeAttack = resolveAttackRound({
+            attackerSkill: foe.attackSkill,
+            weaponAttackModifier: foe.weaponAttackModifier,
+            defenderDexterity: gameState.stats.dexterity,
+            defenderArmourModifier: heroArmourModifier,
+            damageRange: foe.damage
+        });
+
+        appendLog(`${foe.name} attacks: ${foeAttack.attackRoll} vs your defence ${foeAttack.defenceRoll}.`);
+
+        if (foeAttack.hit) {
+            modifyStat('endurance', -foeAttack.damage);
+            appendLog(`The troll hits you for ${foeAttack.damage} damage.`);
+        } else {
+            appendLog('You evade the troll strike.');
+        }
+
+        updateDisplay();
+
+        if (gameState.stats.endurance <= 0) {
+            endCombat('You are reduced to 0 endurance, fall unconscious, and are defeated.', 'start');
+        }
+    });
+
+    fleeButton.addEventListener('click', function() {
+        if (combatEnded) {
+            return;
+        }
+
+        appendLog('You flee into the forest before the troll can pin you down.');
+        endCombat('You escaped the forest troll.', 'forest');
+    });
+
+    renderWeapons();
+    updateDisplay();
+    appendLog('Combat begins. Choose a weapon and fight round by round or flee.');
+});
+</script>


### PR DESCRIPTION
### Motivation
- Provide a playable combat encounter on the darker forest path where Lyra must face a forest troll in round-based combat. 
- Allow players to use items from their inventory as weapons so equipment, skills and modifiers affect combat outcomes. 
- Keep combat logic reusable and compatible with existing skill and inventory systems.

### Description
- Added `scenes/dark_path.html`, a UI-driven encounter with a weapon selector, `Attack`/`Flee` actions, endurance displays, a status line, and a rolling combat log. 
- Extended `ITEM_CATALOG` in `assets/js/game.js` to include combat metadata for weapons (`Bow`, `Dagger`) including `skill`, `attackModifier`, and `damage` range. 
- Implemented combat helpers in `assets/js/game.js`: `rollDie`, `rollRange`, `getSkillLevel`, `getCombatWeaponsFromInventory` (backwards-compatible with older saved items), and `resolveAttackRound` which computes attack vs defence and damage. 
- Added styling for the combat panel and log in `assets/css/main.scss` to match the existing UI theme.

### Testing
- Ran `node --check assets/js/game.js` to validate the updated JS and it completed successfully. 
- Served the site via `python3 -m http.server 8000 --bind 0.0.0.0` and loaded `scenes/dark_path.html` in a headless browser to visually verify the encounter and interactions, which succeeded. 
- Captured a Playwright screenshot artifact of the combat scene to confirm UI rendering and interactivity.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac8946bd048320ac2b08af6c8a3ae9)