### PR TITLE
Add `_data/possible_skills.yml` and reference it in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,6 @@ In "The Echoes of Aethoria," you play as Lyra, the last surviving member of the 
 - Story passages and choices will be implemented as linked HTML pages or dynamically loaded content.
 - Combat and skill checks will use JavaScript for calculations and outcome determination.
 - Inventory and character progression will be saved using web local storage or cookies, allowing players to return to their adventure at any time.
+- Possible player skills are documented in `_data/possible_skills.yml` to make future skill-tree expansion easier.
 
 "The Echoes of Aethoria" combines the classic feel of gamebooks with modern web technologies, creating an engaging and replayable adventure that captures the spirit of "Lone Wolf" while offering a unique experience for a new generation of players.

--- a/_data/possible_skills.yml
+++ b/_data/possible_skills.yml
@@ -1,0 +1,70 @@
+# Catalog of potential player skills for Lyra.
+# Skills are grouped by discipline, then by branch.
+- discipline: Combat
+  branches:
+    - name: Melee
+      skills:
+        - name: Swordplay
+          description: Precision blade technique that improves hit chance and control in close-quarters duels.
+        - name: Shield Bash
+          description: Offensive shield maneuver used to stagger enemies and open them to follow-up attacks.
+        - name: Riposte
+          description: Counterattack discipline that converts successful defenses into immediate strikes.
+        - name: Whirlwind Strike
+          description: Spinning melee assault designed to pressure multiple adjacent foes.
+    - name: Ranged
+      skills:
+        - name: Longbow Aim
+          description: Core archery training for accuracy and stability at medium-to-long range.
+        - name: Quick Draw
+          description: Fast ready-and-release technique that shortens time between ranged attacks.
+        - name: Piercing Shot
+          description: Focused arrow placement that improves effectiveness against armored targets.
+        - name: Hawk Eye
+          description: Keen-sight discipline that improves target acquisition and weak-point spotting.
+
+- discipline: Survival
+  branches:
+    - name: Tracking
+      skills:
+        - name: Trail Reading
+          description: Ability to interpret footprints, disturbances, and subtle terrain clues.
+        - name: Scent Marking
+          description: Fieldcraft method for identifying route markers, prey trails, and territorial signs.
+        - name: Silent Pursuit
+          description: Stealth tracking technique that minimizes noise and visible movement while following targets.
+        - name: Beast Lore
+          description: Knowledge of creature behavior used to predict movement patterns and avoid ambushes.
+    - name: Fieldcraft
+      skills:
+        - name: Camp Setup
+          description: Practical expertise in building safe camps, lookout points, and temporary defenses.
+        - name: Foraging
+          description: Skill in locating edible plants, clean water sources, and useful wilderness materials.
+        - name: Herbal Remedy
+          description: Preparation of curatives and poultices from gathered herbs for recovery and treatment.
+        - name: Weather Sense
+          description: Environmental awareness that anticipates storms, temperature shifts, and travel hazards.
+
+- discipline: Mysticism
+  branches:
+    - name: Runes
+      skills:
+        - name: Glyph Etching
+          description: Foundational rune-scribing practice for creating basic magical inscriptions.
+        - name: Ward Sigils
+          description: Protective sigil craft that reinforces defenses against hostile magical effects.
+        - name: Resonance Binding
+          description: Arcane attunement technique used to anchor and stabilize volatile energies.
+        - name: Rune Weaving
+          description: Advanced rune composition that combines multiple inscriptions into layered effects.
+    - name: Mind Arts
+      skills:
+        - name: Focus Trance
+          description: Meditative discipline that sharpens concentration and sustains mental resilience.
+        - name: Echo Sense
+          description: Extrasensory perception used to detect hidden presences and magical traces nearby.
+        - name: Spirit Lure
+          description: Mystical influence technique that draws and redirects wandering spirit entities.
+        - name: Astral Recall
+          description: Mnemonic rite that restores fragmented memories and improves lore recollection.


### PR DESCRIPTION
### Motivation
- Provide a canonical, machine-readable catalog of potential player skills to support future skill-tree expansion and keep skill definitions separate from narrative documentation.

### Description
- Add `_data/possible_skills.yml` containing a structured list of skills grouped by `discipline`, `branches`, and `skills` for Combat, Survival, and Mysticism.
- Update `README.md` to reference `_data/possible_skills.yml` as the documented location for possible player skills to ease future development.
- The new YAML includes branch-level entries such as Melee, Ranged, Tracking, Fieldcraft, Runes, and Mind Arts with descriptions for each skill.

### Testing
- No automated tests were added or executed for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac9225eb908320857f20ba9ce20b5a)