### PR TITLE
Replace inventory popup form with drag-and-drop equipping

### DIFF
--- a/_includes/inventory_popup.html
+++ b/_includes/inventory_popup.html
@@ -1,21 +1,7 @@
 <div id="inventory-popup" class="popup">
     <div class="popup-content">
         <h2>Inventory</h2>
-        <form id="inventory-add-form">
-            <label for="inventory-item-select">Item</label>
-            <select id="inventory-item-select"></select>
-
-            <label for="inventory-compartment-select">Compartment</label>
-            <select id="inventory-compartment-select">
-                <option value="back">Back</option>
-                <option value="belt">Belt</option>
-                <option value="hands">Hands</option>
-                <option value="armour">Armour</option>
-            </select>
-
-            <button type="submit">Add Item</button>
-        </form>
-
+        <p class="inventory-drag-helper">Drag an available item into a compartment to equip it.</p>
         <p id="inventory-message" aria-live="polite"></p>
         <div id="inventory-list"></div>
     </div>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -193,30 +193,11 @@ h1 {
     }
 }
 
-#inventory-add-form {
-    display: grid;
-    gap: 8px;
 
-    label {
-        font-size: 0.78rem;
-        text-transform: uppercase;
-        letter-spacing: 0.04em;
-        color: rgba($parchment, 0.85);
-    }
-
-    select,
-    button {
-        background: rgba($stone, 0.8);
-        color: $parchment;
-        border: 1px solid rgba($rune-gold, 0.22);
-        border-radius: 8px;
-        padding: 8px 10px;
-    }
-
-    button {
-        margin-bottom: 4px;
-        cursor: pointer;
-    }
+.inventory-drag-helper {
+    margin: 0 0 10px;
+    color: rgba($parchment, 0.8);
+    font-size: 0.82rem;
 }
 
 #inventory-message {
@@ -353,6 +334,11 @@ h1 {
             border-radius: 8px;
             margin-bottom: 8px;
             font-size: 0.88rem;
+        }
+
+        .inventory-items-available > .available-item {
+            justify-content: flex-start;
+            cursor: grab;
         }
 
         .inventory-items > li:not(.empty-slot) {

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -343,28 +343,30 @@ function setInventoryMessage(message) {
     }
 }
 
-function updateInventoryItemSelect() {
-    const itemSelect = document.getElementById('inventory-item-select');
+function addAvailableItem(itemName, targetCompartment = 'back') {
+    if (!itemName || hasItemByName(itemName)) {
+        return false;
+    }
 
-    if (!itemSelect) {
+    const itemData = getItemData(itemName);
+    const compartment = itemData.requiredCompartment || targetCompartment;
+    return addToInventory(itemName, compartment);
+}
+
+function handleInventoryDrop(event, targetCompartment) {
+    event.preventDefault();
+
+    const itemId = event.dataTransfer.getData('text/plain');
+    if (itemId) {
+        moveItem(itemId, targetCompartment);
         return;
     }
 
-    itemSelect.innerHTML = '';
+    const itemName = event.dataTransfer.getData('application/x-available-item')
+        || event.dataTransfer.getData('text/inventory-item-name');
 
-    Object.entries(ITEM_CATALOG).forEach(([itemName, itemData]) => {
-        const option = document.createElement('option');
-        option.value = itemName;
-        option.textContent = `${itemName} (W:${itemData.weight}, S:${itemData.space})`;
-        option.disabled = hasItemByName(itemName);
-        itemSelect.appendChild(option);
-    });
-
-    if (itemSelect.options.length > 0 && itemSelect.selectedOptions[0]?.disabled) {
-        const enabledOption = Array.from(itemSelect.options).find(option => !option.disabled);
-        if (enabledOption) {
-            itemSelect.value = enabledOption.value;
-        }
+    if (itemName) {
+        addAvailableItem(itemName, targetCompartment);
     }
 }
 
@@ -463,11 +465,7 @@ function updateInventoryDisplay() {
         });
 
         list.addEventListener('drop', event => {
-            event.preventDefault();
-            const itemId = event.dataTransfer.getData('text/plain');
-            if (itemId) {
-                moveItem(itemId, compartment);
-            }
+            handleInventoryDrop(event, compartment);
         });
 
         if (gameState.inventory[compartment].length > 0) {
@@ -515,7 +513,42 @@ function updateInventoryDisplay() {
         inventoryList.appendChild(section);
     });
 
-    updateInventoryItemSelect();
+    const availableItemsSection = document.createElement('section');
+    availableItemsSection.className = 'inventory-compartment inventory-available-items';
+
+    const availableHeading = document.createElement('h3');
+    availableHeading.textContent = 'Available Items';
+    availableItemsSection.appendChild(availableHeading);
+
+    const availableList = document.createElement('ul');
+    availableList.className = 'inventory-items inventory-items-available';
+
+    const availableItems = Object.entries(ITEM_CATALOG).filter(([itemName]) => !hasItemByName(itemName));
+
+    if (availableItems.length > 0) {
+        availableItems.forEach(([itemName, itemData]) => {
+            const listItem = document.createElement('li');
+            listItem.draggable = true;
+            listItem.className = 'available-item';
+            listItem.dataset.itemName = itemName;
+            listItem.textContent = `${itemName} (W:${itemData.weight}, S:${itemData.space})`;
+
+            listItem.addEventListener('dragstart', event => {
+                event.dataTransfer.setData('application/x-available-item', itemName);
+                event.dataTransfer.setData('text/inventory-item-name', itemName);
+            });
+
+            availableList.appendChild(listItem);
+        });
+    } else {
+        const emptyLine = document.createElement('li');
+        emptyLine.textContent = 'All known items are equipped.';
+        emptyLine.className = 'empty-slot';
+        availableList.appendChild(emptyLine);
+    }
+
+    availableItemsSection.appendChild(availableList);
+    inventoryList.appendChild(availableItemsSection);
 }
 
 function updateStatsDisplay() {
@@ -646,7 +679,6 @@ function loadGame() {
         gameState.stats = loadedState.stats || gameState.stats;
     }
 
-    updateInventoryItemSelect();
     updateInventoryDisplay();
     updateStatsDisplay();
     updateSkillsDisplay();
@@ -693,37 +725,11 @@ function setupEdgePopups() {
 
 function setupInventoryPopup() {
     const popup = document.getElementById('inventory-popup');
-    const addForm = document.getElementById('inventory-add-form');
-    const itemSelect = document.getElementById('inventory-item-select');
-    const compartmentSelect = document.getElementById('inventory-compartment-select');
 
-    if (!popup || !addForm || !itemSelect || !compartmentSelect) {
+    if (!popup) {
         return;
     }
-
-    itemSelect.addEventListener('change', () => {
-        const selectedItemData = getItemData(itemSelect.value);
-
-        if (selectedItemData.requiredCompartment) {
-            compartmentSelect.value = selectedItemData.requiredCompartment;
-        }
-    });
-
-    addForm.addEventListener('submit', event => {
-        event.preventDefault();
-
-        const itemName = itemSelect.value;
-        const selectedItemData = getItemData(itemName);
-        const compartment = selectedItemData.requiredCompartment || compartmentSelect.value;
-
-        if (selectedItemData.requiredCompartment) {
-            compartmentSelect.value = selectedItemData.requiredCompartment;
-        }
-
-        addToInventory(itemName, compartment);
-    });
 }
-
 function setupSkillsPopup() {
     const popup = document.getElementById('skills-popup');
 


### PR DESCRIPTION
### Motivation
- The inventory popup used a form to add items which is inconsistent with the in-place drag-and-drop UX used for moving items between compartments. 
- Provide a single, unified drag-and-drop flow that lets players equip catalogue items by dragging them into compartments.

### Description
- Removed the add-item form from `_includes/inventory_popup.html` and replaced it with a short helper line to explain dragging items. 
- Added an "Available Items" section to `updateInventoryDisplay` in `assets/js/game.js` that lists unequipped catalog items as draggable entries. 
- Implemented `handleInventoryDrop` and `addAvailableItem` in `assets/js/game.js` to accept either an equipped item ID (for compartment-to-compartment moves) or an available item name (to equip new items) and route both to existing validation and add/move logic. 
- Removed obsolete form setup and select logic from `setupInventoryPopup` and updated styles in `assets/css/main.scss` to remove form rules and add styles for the drag helper and available items list. 

### Testing
- Ran `node --check assets/js/game.js` to validate the modified JavaScript and it succeeded. 
- Launched a local server with `python -m http.server 4000` and manually verified the inventory popup UI and interactions. 
- Captured a Playwright screenshot of the inventory popup after changes to confirm the new available-items list and drag helper render correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac97d9cfa483209626b783cfd7adb9)